### PR TITLE
Add comprehensive test cases for StreamAttendee and related entities  

### DIFF
--- a/src/test/java/com/fleencorp/feen/model/domain/stream/StreamAttendeeTest.java
+++ b/src/test/java/com/fleencorp/feen/model/domain/stream/StreamAttendeeTest.java
@@ -1,0 +1,291 @@
+package com.fleencorp.feen.model.domain.stream;
+
+import com.fleencorp.feen.constant.stream.StreamAttendeeRequestToJoinStatus;
+import com.fleencorp.feen.model.domain.user.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class StreamAttendeeTest {
+
+  @DisplayName("Create empty StreamAttendee")
+  @Test
+  void create_empty_stream_attendee() {
+    // GIVEN
+    final StreamAttendee streamAttendee = new StreamAttendee();
+
+    // ASSERT
+    assertNotNull(streamAttendee);
+  }
+
+  @DisplayName("Create a null StreamAttendee")
+  @Test
+  void create_null_stream_attendee(){
+    // GIVEN
+    final StreamAttendee streamAttendee = null;
+
+    // ASSERT
+    assertNull(streamAttendee);
+  }
+
+  @DisplayName("Create a StreamAttendee without id")
+  @Test
+  void create_stream_attendee_without_id(){
+    // GIVEN
+    final StreamAttendee streamAttendee = new StreamAttendee();
+
+    // ASSERT
+    assertNull(streamAttendee.getStreamAttendeeId());
+  }
+
+  @DisplayName("Create a StreamAttendee without id")
+  @Test
+  void create_stream_attendee_with_id(){
+    // GIVEN
+    final StreamAttendee streamAttendee = new StreamAttendee();
+    streamAttendee.setStreamAttendeeId(1L);
+
+    // ASSERT
+    assertNotNull(streamAttendee.getStreamAttendeeId());
+  }
+
+  @DisplayName("Ensure StreamAttendee Id is not null")
+  @Test
+  void ensure_stream_attendee_id_is_not_null() {
+//    GIVEN
+    StreamAttendee streamAttendee = new StreamAttendee();
+    streamAttendee.setStreamAttendeeId(1L);
+//    ASSERT
+    assertNotNull(streamAttendee.getStreamAttendeeId());
+  }
+
+  @DisplayName("Ensure StreamAttendee Id is null")
+  @Test
+  void ensure_stream_attendee_id_is_null() {
+//    GIVEN
+    StreamAttendee streamAttendee = new StreamAttendee();
+//    ASSERT
+    assertNull(streamAttendee.getStreamAttendeeId());
+  }
+
+  @DisplayName("Ensure StreamAttendee Ids are equal")
+  @Test
+  void ensure_stream_attendee_ids_are_equal() {
+//    GIVEN
+
+    Long streamAttendeeId = 1L;
+    StreamAttendee streamAttendee = new StreamAttendee();
+    streamAttendee.setStreamAttendeeId(1L);
+
+//    ASSERT
+    assertEquals(streamAttendee.getStreamAttendeeId(), streamAttendeeId);
+  }
+
+  @DisplayName("Ensure StreamAttendee Ids are not equal")
+  @Test
+  void ensure_stream_attendee_ids_are_not_equal() {
+//    GIVEN
+
+    Long streamAttendeeId = 1L;
+    StreamAttendee streamAttendee = new StreamAttendee();
+    streamAttendee.setStreamAttendeeId(2L);
+
+//    ASSERT
+    assertNotEquals(streamAttendee.getMemberId(), streamAttendeeId);
+  }
+
+  @DisplayName("Ensure fleenStream is not null")
+  @Test
+  void ensure_fleen_stream_is_not_null() {
+//    GIVEN
+    FleenStream fleenStream = new FleenStream();
+    fleenStream.setFleenStreamId(1L);
+
+    StreamAttendee streamAttendee = new StreamAttendee();
+    streamAttendee.setFleenStream(fleenStream);
+//    ASSERT
+    assertNotNull(streamAttendee.getFleenStream());
+  }
+
+  @DisplayName("Ensure fleenStream is null")
+  @Test
+  void ensure_fleen_stream_is_null() {
+//    GIVEN
+    StreamAttendee streamAttendee = new StreamAttendee();
+
+//    ASSERT
+    assertNull(streamAttendee.getFleenStream());
+  }
+
+  @DisplayName("Ensure fleenStreams are equal")
+  @Test
+  void ensure_fleen_streams_are_equal() {
+//    GIVEN
+    FleenStream fleenStream = new FleenStream();
+
+    StreamAttendee streamAttendee = new StreamAttendee();
+    streamAttendee.setFleenStream(fleenStream);
+
+//    ASSERT
+    assertEquals(streamAttendee.getFleenStream(), fleenStream);
+  }
+
+  @DisplayName("Ensure fleenStreams are not equal")
+  @Test
+  void ensure_fleen_streams_are_not_equal() {
+//    GIVEN
+    FleenStream fleenStream = new FleenStream();
+    fleenStream.setFleenStreamId(1L);
+
+    FleenStream fleenStream1 = new FleenStream();
+    fleenStream.setFleenStreamId(2L);
+
+    StreamAttendee streamAttendee = new StreamAttendee();
+    streamAttendee.setFleenStream(fleenStream1);
+
+//    ASSERT
+    assertNotEquals(streamAttendee.getFleenStream(), fleenStream);
+  }
+
+
+  @DisplayName("Ensure member is not null")
+  @Test
+  void ensure_member_is_not_null() {
+//    GIVEN
+    Member member = new Member();
+    member.setMemberId(1L);
+
+    StreamAttendee streamAttendee = new StreamAttendee();
+    streamAttendee.setMember(member);
+//    ASSERT
+    assertNotNull(streamAttendee.getMember());
+  }
+
+  @DisplayName("Ensure member is null")
+  @Test
+  void ensure_member_is_null() {
+//    GIVEN
+    StreamAttendee streamAttendee = new StreamAttendee();
+
+//    ASSERT
+    assertNull(streamAttendee.getMember());
+  }
+
+  @DisplayName("Ensure members are equal")
+  @Test
+  void ensure_members_are_equal() {
+//    GIVEN
+    Member member = new Member();
+
+    StreamAttendee streamAttendee = new StreamAttendee();
+    streamAttendee.setMember(member);
+
+//    ASSERT
+    assertEquals(streamAttendee.getMember(), member);
+  }
+
+  @DisplayName("Ensure members are not equal")
+  @Test
+  void ensure_members_are_not_equal() {
+//    GIVEN
+    Member member = new Member();
+    member.setMemberId(1L);
+
+    Member member1 = new Member();
+    member1.setMemberId(2L);
+
+    StreamAttendee streamAttendee = new StreamAttendee();
+    streamAttendee.setMember(member1);
+
+//    ASSERT
+    assertNotEquals(streamAttendee.getMember(), member);
+  }
+
+
+  @DisplayName("Ensure request to join status is not null")
+  @Test
+  void ensure_request_to_join_status_is_not_null() {
+//    GIVEN
+    StreamAttendee streamAttendee = new StreamAttendee();
+    streamAttendee.setRequestToJoinStatus(StreamAttendeeRequestToJoinStatus.PENDING);
+
+//    ASSERT
+    assertNotNull(streamAttendee.getRequestToJoinStatus());
+  }
+
+  @DisplayName("Ensure request to join status is null")
+  @Test
+  void ensure_stream_attendee_request_to_join_status_is_null() {
+//    GIVEN
+    StreamAttendee streamAttendee = new StreamAttendee();
+
+//    ASSERT
+    assertNull(streamAttendee.getRequestToJoinStatus());
+  }
+
+
+  @DisplayName("Ensure isAttending is not null")
+  @Test
+  void ensure_is_attending_is_not_null() {
+//    GIVEN
+    StreamAttendee streamAttendee = new StreamAttendee();
+    streamAttendee.setIsAttending(false);
+
+//    ASSERT
+    assertNotNull(streamAttendee.getIsAttending());
+  }
+
+  @DisplayName("Ensure isAttending is null")
+  @Test
+  void ensure_is_attending_is_null() {
+//    GIVEN
+    StreamAttendee streamAttendee = new StreamAttendee();
+
+//    ASSERT
+    assertNull(streamAttendee.getIsAttending());
+  }
+
+  @DisplayName("Ensure attendee comment is null")
+  @Test
+  void ensure_attendee_comment_is_null() {
+//    GIVEN
+    StreamAttendee streamAttendee = new StreamAttendee();
+
+//    ASSERT
+    assertNull(streamAttendee.getAttendeeComment());
+  }
+
+  @DisplayName("Ensure attendee comment is not null")
+  @Test
+  void ensure_attendee_comment_is_not_null() {
+//    GIVEN
+    StreamAttendee streamAttendee = new StreamAttendee();
+    streamAttendee.setAttendeeComment("hello");
+
+//    ASSERT
+    assertNotNull(streamAttendee.getAttendeeComment());
+  }
+
+  @DisplayName("Ensure organizer comment is null")
+  @Test
+  void ensure_organizer_comment_is_null() {
+//    GIVEN
+    StreamAttendee streamAttendee = new StreamAttendee();
+
+//    ASSERT
+    assertNull(streamAttendee.getOrganizerComment());
+  }
+
+  @DisplayName("Ensure organizer comment is not null")
+  @Test
+  void ensure_organizer_comment_is_not_null() {
+//    GIVEN
+    StreamAttendee streamAttendee = new StreamAttendee();
+    streamAttendee.setOrganizerComment("hello");
+
+//    ASSERT
+    assertNotNull(streamAttendee.getOrganizerComment());
+  }
+
+}


### PR DESCRIPTION


This pull request introduces a new `StreamAttendeeTest` class and comprehensive test cases to ensure the proper functionality of the `StreamAttendee` entity and its related attributes.  

#### Summary of Changes  
1. **Created `StreamAttendeeTest` class.**  
2. **Added tests for basic `StreamAttendee` creation:**  
   - Verified the creation of an empty `StreamAttendee` instance.  
   - Confirmed that a null `StreamAttendee` instance is correctly handled.  

3. **Added tests for `StreamAttendee` ID scenarios:**  
   - Verified the creation of `StreamAttendee` without an ID.  
   - Verified the creation of `StreamAttendee` with an ID.  
   - Ensured `StreamAttendee` ID is not null.  
   - Ensured `StreamAttendee` ID is null.  
   - Ensured `StreamAttendee` IDs are equal.  
   - Ensured `StreamAttendee` IDs are not equal.  

4. **Added tests for `FleenStream` relationships:**  
   - Ensured `FleenStream` is not null.  
   - Ensured `FleenStream` is null.  
   - Ensured `FleenStreams` are equal.  
   - Ensured `FleenStreams` are not equal.  

5. **Added tests for `Member` relationships:**  
   - Ensured `Member` is not null.  
   - Ensured `Member` is null.  
   - Ensured `Members` are equal.  
   - Ensured `Members` are not equal.  

6. **Added tests for `StreamAttendee` properties:**  
   - Ensured request-to-join status is not null.  
   - Ensured request-to-join status is null.  
   - Ensured `isAttending` is not null.  
   - Ensured `isAttending` is null.  
   - Ensured attendee comment is not null.  
   - Ensured attendee comment is null.  
   - Ensured organizer comment is not null.  
   - Ensured organizer comment is null.  

## Why This Change Is Necessary  
These tests enhance the reliability of the codebase by verifying the behavior of the `StreamAttendee` entity under various conditions. They ensure relationships, properties, and logic function as intended.  

## Additional Notes  
- All tests were written using JUnit and follow proper assertions for validation.  
- Future modifications to the `StreamAttendee` entity or its relationships can be easily validated against these tests.  
